### PR TITLE
Output what gerun is running in the debug info.

### DIFF
--- a/gerun-intel
+++ b/gerun-intel
@@ -5,9 +5,23 @@
 
 # For licensing terms, see LICENSE.txt
 
-mpirun \
+# See if GERUN_PATH is set, otherwise guess it out from $0.
+export GERUN_PATH="${GERUN_PATH:-$(dirname $(readlink -f $(which $0)))}"
+
+# Load function definitions.
+source $GERUN_PATH/gerunlib.sh
+
+mpirun_cmd=(mpirun \
   --rsh=ssh \
   -machinefile "$TMPDIR/machines.unique" \
   -np "$GERUN_PROCS" \
   -rr \
-  "$@"
+  "$@")
+
+if [[ "$GERUN_SILENT" != "yes" ]]; then 
+  stderrmsg "GErun command being run:"
+  stderrmsg " ${mpirun_cmd[@]}"
+fi
+
+"${mpirun_cmd[@]}"
+

--- a/gerun-openmpi
+++ b/gerun-openmpi
@@ -5,7 +5,21 @@
 
 # For licensing terms, see LICENSE.txt
 
-mpirun \
+# See if GERUN_PATH is set, otherwise guess it out from $0.
+export GERUN_PATH="${GERUN_PATH:-$(dirname $(readlink -f $(which $0)))}"
+
+# Load function definitions.
+source $GERUN_PATH/gerunlib.sh
+
+mpirun_cmd=(mpirun \
   -machinefile "$TMPDIR/machines" \
   -np "$GERUN_PROCS" \
-  "$@"
+  "$@")
+
+if [[ "$GERUN_SILENT" != "yes" ]]; then
+  stderrmsg "GErun command being run:"
+  stderrmsg " ${mpirun_cmd[@]}"
+fi
+
+"${mpirun_cmd[@]}"
+

--- a/gerun-openmpi-sge
+++ b/gerun-openmpi-sge
@@ -16,7 +16,15 @@ source $GERUN_PATH/gerunlib.sh
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 
 if [[ "$OMP_NUM_THREADS" != "1" ]]; then
-  mpirun --bynode -np "$GERUN_PROCS" "$@"
+  mpirun_cmd=(mpirun --bynode -np "$GERUN_PROCS" "$@")
 else
-  mpirun  "$@"
+  mpirun_cmd=(mpirun  "$@")
 fi
+
+if [[ "$GERUN_SILENT" != "yes" ]]; then
+  stderrmsg "GErun command being run:"
+  stderrmsg " ${mpirun_cmd[@]}"
+fi
+
+"${mpirun_cmd[@]}"
+

--- a/gerun-qlc
+++ b/gerun-qlc
@@ -5,7 +5,21 @@
 
 # For licensing terms, see LICENSE.txt
 
-mpirun \
+# See if GERUN_PATH is set, otherwise guess it out from $0.
+export GERUN_PATH="${GERUN_PATH:-$(dirname $(readlink -f $(which $0)))}"
+
+# Load function definitions.
+source $GERUN_PATH/gerunlib.sh
+
+mpirun_cmd=(mpirun \
   -m "$TMPDIR/machines" \
   -np "$GERUN_PROCS" \
-  "$@"
+  "$@")
+
+if [[ "$GERUN_SILENT" != "yes" ]]; then
+  stderrmsg "GErun command being run:"
+  stderrmsg " ${mpirun_cmd[@]}"
+fi
+
+"${mpirun_cmd[@]}"
+


### PR DESCRIPTION
Updated all the `gerun-whatevers` so they add the mpirun commandline gerun is actually running to the gerun debug info in .e.

Tested with OpenMPI 3.1.4 for GNU 7.3.0 and Intel MPI 2018 update 3.