### PR TITLE
Resolve OpenMPI issues raised in https://github.com/UCL-RITS/research-computing/issues/1685

### DIFF
--- a/gerun-openmpi
+++ b/gerun-openmpi
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# Parallel launcher for the various PEs on Legion.
+# Parallel launcher for the various PEs on UCL RC Systems.
 # Dr Owain Kenway, UCL
 
 # For licensing terms, see LICENSE.txt
+
+set -o
 
 # See if GERUN_PATH is set, otherwise guess it out from $0.
 export GERUN_PATH="${GERUN_PATH:-$(dirname $(readlink -f $(which $0)))}"
@@ -14,6 +16,8 @@ source $GERUN_PATH/gerunlib.sh
 mpirun_cmd=(mpirun \
   -machinefile "$TMPDIR/machines" \
   -np "$GERUN_PROCS" \
+  --map-by node \
+  --bind-to none \
   "$@")
 
 if [[ "$GERUN_SILENT" != "yes" ]]; then

--- a/gerun-openmpi
+++ b/gerun-openmpi
@@ -13,12 +13,21 @@ export GERUN_PATH="${GERUN_PATH:-$(dirname $(readlink -f $(which $0)))}"
 # Load function definitions.
 source $GERUN_PATH/gerunlib.sh
 
-mpirun_cmd=(mpirun \
-  -machinefile "$TMPDIR/machines" \
-  -np "$GERUN_PROCS" \
-  --map-by node \
-  --bind-to none \
-  "$@")
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+
+if [[ "$OMP_NUM_THREADS" != "1" ]]; then
+  mpirun_cmd=(mpirun \
+    -machinefile "$TMPDIR/machines" \
+    -np "$GERUN_PROCS" \
+    --map-by node \
+    --bind-to none \
+    "$@")
+else
+  mpirun_cmd=(mpirun \
+    -machinefile "$TMPDIR/machines" \
+    -np "$GERUN_PROCS" \
+    "$@")
+fi
 
 if [[ "$GERUN_SILENT" != "yes" ]]; then
   stderrmsg "GErun command being run:"

--- a/gerun-openmpi-sge
+++ b/gerun-openmpi-sge
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Parallel launcher for the various PEs on Legion.
+# Parallel launcher for the various PEs on UCL RC Systems.
 # Dr Owain Kenway, UCL
 
 # For licensing terms, see LICENSE.txt
@@ -16,9 +16,9 @@ source $GERUN_PATH/gerunlib.sh
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 
 if [[ "$OMP_NUM_THREADS" != "1" ]]; then
-  mpirun_cmd=(mpirun --bynode -np "$GERUN_PROCS" "$@")
+  mpirun_cmd=(mpirun --map-by node --bind-to none -np "$GERUN_PROCS" "$@")
 else
-  mpirun_cmd=(mpirun  "$@")
+  mpirun_cmd=(mpirun --map-by node --bind-to none "$@")
 fi
 
 if [[ "$GERUN_SILENT" != "yes" ]]; then

--- a/gerun-openmpi-sge
+++ b/gerun-openmpi-sge
@@ -18,7 +18,7 @@ export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 if [[ "$OMP_NUM_THREADS" != "1" ]]; then
   mpirun_cmd=(mpirun --map-by node --bind-to none -np "$GERUN_PROCS" "$@")
 else
-  mpirun_cmd=(mpirun --map-by node --bind-to none "$@")
+  mpirun_cmd=(mpirun "$@")
 fi
 
 if [[ "$GERUN_SILENT" != "yes" ]]; then


### PR DESCRIPTION
Issue https://github.com/UCL-RITS/research-computing/issues/1685 described two problems with the OpenMPI wrappers:

1. `--bynode` has been deprecated.
2. In hybrid jobs binding breaks OpenMPI jobs.

This pull request resolves these two issues.